### PR TITLE
fix: correct GNU Stow usage in blog posts

### DIFF
--- a/app/content/blogs/en/gnu_stow.mdx
+++ b/app/content/blogs/en/gnu_stow.mdx
@@ -33,22 +33,24 @@ Stow **mirrors** your configuration file structure in your HOME directory, ensur
 
 ## The structure looks like this:
 
+GNU Stow works with **packages** - subdirectories within your dotfiles folder. Each package mirrors your HOME directory structure:
+
 ```
 home/
     dotfiles/
-        .config/
-            zsh/
-                [...some files]
-        .local/
-            share/
-                uzbl/
-                    [...some files]
-        .vim/
-            [...some files]
-        .bashrc
-        .bash_profile
-        .bash_logout
-        .vimrc
+        zsh/
+            .zshrc
+            .config/
+                zsh/
+                    [...zsh config files]
+        vim/
+            .vimrc
+            .vim/
+                [...vim files]
+        bash/
+            .bashrc
+            .bash_profile
+            .bash_logout
 ```
 
 Let's explore how to set up and use GNU Stow:
@@ -67,20 +69,23 @@ If you use MacOS and have homebrew installed, simply run:
    cd ~/dotfiles
 ```
 
-3. To prevent issues, let's copy the original dotfiles. We'll test with .zshrc file.
+3. Create package directories for your configs. We'll start with zsh as an example:
 
 ```
-   mkdir ~/copy_dotfiles
-   cp ~/.zshrc ~/copy_dotfiles/.zshrc
-   cp -R ~/.config ~/copy_dotfiles/
+   mkdir -p ~/dotfiles/zsh
 ```
 
-4. Move configuration files to the newly created ~/dotfiles/ directory.
+4. Move configuration files to the package directory, preserving any subdirectory structure.
 
+For .zshrc (which goes directly in HOME):
 ```
-   cd $HOME/dotfiles
-   mv ~/copy_dotfiles/.zshrc ~/dotfiles/.zshrc
-   mv ~/copy_dotfiles/.config ~/dotfiles/.config
+   mv ~/.zshrc ~/dotfiles/zsh/.zshrc
+```
+
+For files in .config (which goes in HOME/.config):
+```
+   mkdir -p ~/dotfiles/zsh/.config
+   mv ~/.config/zsh ~/dotfiles/zsh/.config/
 ```
 
 5. Create symlinks
@@ -90,25 +95,31 @@ Navigate to your **dotfiles directory** and use Stow to create symlinks:
 ```
 cd ~/dotfiles
 stow zsh
-stow config
 ```
+
+This creates symlinks from your HOME directory to the files in ~/dotfiles/zsh/
 
 6. Verify
 
+Check your HOME directory to see the symlinks:
+
 ```
-   ll -a
+   ls -la ~/ | grep zshrc
 ```
 
-If successful, it should look like this:
+You should see something like: `.zshrc -> dotfiles/zsh/.zshrc`
+
+If successful, your dotfiles directory structure should look like this:
 
 ![dotfiles directory](/blog/gnu_stow/dotfiles_directory.png)
 
-Our HOME directory will look like this:
+And your HOME directory will have symlinks like this:
 
 ![old config directory](/blog/gnu_stow/old_config_directory.png)
 
 7. To track your dotfiles with Git:
-	 Using Git ensures that you can **track changes, revert mistakes, and sync dotfiles across different machines**. To initialize Git and commit your dotfiles:
+
+Using Git ensures that you can **track changes, revert mistakes, and sync dotfiles across different machines**. To initialize Git and commit your dotfiles:
 
 ```
    cd ~/dotfiles
@@ -116,6 +127,8 @@ Our HOME directory will look like this:
    git add .
    git commit -m "Initial commit of dotfiles"
 ```
+
+**Tip:** You can create additional packages for other tools (vim, tmux, bash, etc.) following the same structure. Then run `stow <package-name>` for each one, or `stow */` to stow all packages at once.
 
 # Additional:
 ### Ignoring Files in Stow

--- a/app/content/blogs/mn/gnu_stow.mdx
+++ b/app/content/blogs/mn/gnu_stow.mdx
@@ -33,22 +33,24 @@ GNU Stow бол симлинк ферм менежер /symlink farm manager/ б
 
 ### Бүтэц ингэж харагдана:
 
+GNU Stow нь **package** буюу багц системтэй ажилладаг - dotfiles хавтас доторх дэд хавтас бүр таны HOME директорийн бүтцийг дуурайна:
+
 ```
 home/
     dotfiles/
-        .config/
-            zsh/
-                [...some files]
-        .local/
-            share/
-                uzbl/
-                    [...some files]
-        .vim/
-            [...some files]
-        .bashrc
-        .bash_profile
-        .bash_logout
-        .vimrc
+        zsh/
+            .zshrc
+            .config/
+                zsh/
+                    [...zsh тохиргооны файлууд]
+        vim/
+            .vimrc
+            .vim/
+                [...vim файлууд]
+        bash/
+            .bashrc
+            .bash_profile
+            .bash_logout
 ```
 
 Дараагийн хэсгүүдэд бид таны dotfiles-ыг үр дүнтэй удирдахын тулд GNU Stow-г хэрхэн тохируулж, ашиглах талаар судалж үзэх болно.
@@ -67,54 +69,66 @@ home/
    cd ~/dotfiles
 ```
 
-3. Ямар нэгэн асуудал үүсч магадгүй гээд dotfiles-ыг ориг хувилбараас нь copy-хийж авъя. .zshrc файл дээр жишээ туршиж үзэе.
+3. Тохиргооны package хавтсууд үүсгэх. Жишээ болгон zsh-ээс эхэлье:
 
 ```
-   mkdir ~/copy_dotfiles
-   cp ~/.zshrc ~/copy_dotfiles/.zshrc
-   cp -R ~/.config ~/copy_dotfiles/
+   mkdir -p ~/dotfiles/zsh
 ```
 
-4. Тохиргооны файлуудаа шинээр үүсгэсэн ~/dotfiles/ хавтсанд хуулая.
+4. Тохиргооны файлуудыг package хавтсанд хуулах, дэд хавтсын бүтцийг хадгална.
 
+.zshrc файлыг (HOME дээр шууд байдаг):
 ```
-   cd $HOME/dotfiles
-   mv ~/copy_dotfiles/.zshrc ~/dotfiles/.zshrc
-   mv ~/copy_dotfiles/.config ~/dotfiles/.config
+   mv ~/.zshrc ~/dotfiles/zsh/.zshrc
+```
+
+.config доторх файлуудыг (HOME/.config дээр байдаг):
+```
+   mkdir -p ~/dotfiles/zsh/.config
+   mv ~/.config/zsh ~/dotfiles/zsh/.config/
 ```
 
 5. Symlinks үүсгэх
 
-```
-   stow -t . ~/dotfiles/.zshrc
-   stow -t . ~/dotfiles/.config
-```
-
-Эсвэл
+**dotfiles хавтас** руугаа ороод Stow ашиглан симлинк үүсгэнэ:
 
 ```
-   stow -t .
+cd ~/dotfiles
+stow zsh
 ```
+
+Энэ нь таны HOME цэсэн дээр ~/dotfiles/zsh/ хавтсан дахь файлууд руу симлинк үүсгэнэ.
 
 6. Шалгаж үзэх
 
+HOME цэсэн дээрх симлинкүүдийг шалгаарай:
+
 ```
-   ll -a
+   ls -la ~/ | grep zshrc
 ```
 
-Хэрвээ амжилттай үүссэн бол дараах зураг шиг харагдах болно.
+Ингэж харагдах ёстой: `.zshrc -> dotfiles/zsh/.zshrc`
+
+Хэрвээ амжилттай үүссэн бол таны dotfiles хавтас дараах зураг шиг харагдах болно:
+
 ![dotfiles directory](/blog/gnu_stow/dotfiles_directory.png)
 
-Бидний HOME цэсэн дээр ингэж харагдана
+Бидний HOME цэсэн дээр симлинкүүд ингэж харагдана:
+
 ![old config directory](/blog/gnu_stow/old_config_directory.png)
 
-7. Git config
+7. Git-ээр хянах
+
+Git ашиглах нь таны **өөрчлөлтүүдийг хянах, буцаах, өөр өөр компьютерүүд дээр dotfiles-ыг синк хийх** боломжийг олгоно. Git эхлүүлж, dotfiles-аа commit хийе:
 
 ```
+   cd ~/dotfiles
    git init
    git add .
    git commit -m "Initial commit of dotfiles"
 ```
+
+**Зөвлөмж:** Бусад хэрэгслүүдэд (vim, tmux, bash гэх мэт) нэмэлт package-үүд үүсгэж болно. Дараа нь package бүрт `stow <package-нэр>` ажиллуулах, эсвэл бүх package-үүдийг зэрэг stow хийхийн тулд `stow */` ашиглаарай.
 
 ### Нэмэлт:
 


### PR DESCRIPTION
Fixed incorrect stow command structure and directory organization in both English and Mongolian GNU Stow blog posts.

Changes:
- Corrected directory structure to use proper package-based organization
- Fixed stow commands to follow GNU Stow best practices
- Updated instructions to create package subdirectories (e.g., zsh/, vim/)
- Improved verification steps with specific symlink checking
- Enhanced Git setup section with better descriptions
- Added tips for stowing multiple packages

The previous tutorial showed incorrect usage by placing files directly in the dotfiles directory and using invalid stow commands. Now follows the proper GNU Stow workflow with package subdirectories.